### PR TITLE
fix: literal map keys as quoted property

### DIFF
--- a/examples/rfc-examples/maps.cddl
+++ b/examples/rfc-examples/maps.cddl
@@ -17,3 +17,10 @@ extensible-map-example-4 = {
     ? "optional-key" ^ => int,
     * tstr => any
 }
+
+example-map = {
+    ? "hyphenated-key": text,
+    ? "another-key": text,
+    ? standardIdentifier: text,
+    ? 1: text,
+}

--- a/src/engines/typescript.rs
+++ b/src/engines/typescript.rs
@@ -276,16 +276,6 @@ impl<'a, 'b: 'a, 'c, Stdout: Write, Stderr: Write> Engine<Stdout, Stderr> {
         self.nested_type1.pop();
         Ok(())
     }
-    fn visit_value(&mut self, value: &cddl::token::Value<'a>) -> cddl::visitor::Result<Error> {
-        match value {
-            cddl::token::Value::INT(value) => write!(self.stdout, "{}", value),
-            cddl::token::Value::UINT(value) => write!(self.stdout, "{}", value),
-            cddl::token::Value::FLOAT(value) => write!(self.stdout, "{}", value),
-            cddl::token::Value::TEXT(value) => write!(self.stdout, "\"{}\"", value),
-            cddl::token::Value::BYTE(value) => write!(self.stdout, "\"{}\"", value),
-        };
-        Ok(())
-    }
     fn visit_array(&mut self, g: &'b cddl::ast::Group<'a>) -> cddl::visitor::Result<Error> {
         for (index, choice) in g.group_choices.iter().enumerate() {
             if index != 0 {
@@ -781,9 +771,13 @@ impl<'a, 'b: 'a, Stdout: Write, Stderr: Write> Visitor<'a, 'b, Error> for Engine
                 write!(self.stdout, "\"{}\"", &ident);
             }
             cddl::ast::MemberKey::Value { value, .. } => {
-                write!(self.stdout, "[");
-                self.visit_value(value)?;
-                write!(self.stdout, "]");
+                match value {
+                    cddl::token::Value::INT(value) => write!(self.stdout, "\"{}\"", value),
+                    cddl::token::Value::UINT(value) => write!(self.stdout, "\"{}\"", value),
+                    cddl::token::Value::FLOAT(value) => write!(self.stdout, "\"{}\"", value),
+                    cddl::token::Value::TEXT(value) => write!(self.stdout, "\"{}\"", value),
+                    cddl::token::Value::BYTE(value) => write!(self.stdout, "\"{}\"", value),
+                };
             }
             cddl::ast::MemberKey::NonMemberKey { .. } => {
                 unimplemented!()

--- a/src/engines/zod.rs
+++ b/src/engines/zod.rs
@@ -651,9 +651,13 @@ impl<'a, 'b: 'a, Stdout: Write, Stderr: Write> Visitor<'a, 'b, Error> for Engine
             cddl::ast::MemberKey::Value { value, .. } => {
                 self.print_group_joiner();
                 self.enter_map();
-                write!(self.stdout, "[");
-                self.visit_value(value)?;
-                write!(self.stdout, "]:");
+                match value {
+                    cddl::token::Value::INT(value) => write!(self.stdout, "\"{}\":", value),
+                    cddl::token::Value::UINT(value) => write!(self.stdout, "\"{}\":", value),
+                    cddl::token::Value::FLOAT(value) => write!(self.stdout, "\"{}\":", value),
+                    cddl::token::Value::TEXT(value) => write!(self.stdout, "\"{}\":", value),
+                    cddl::token::Value::BYTE(value) => write!(self.stdout, "\"{}\":", value),
+                };
             }
             cddl::ast::MemberKey::NonMemberKey { .. } => {
                 unimplemented!()

--- a/tests/snapshots/typescript__it_works_with_maps-2.snap
+++ b/tests/snapshots/typescript__it_works_with_maps-2.snap
@@ -1,14 +1,14 @@
 ---
 source: tests/typescript.rs
-assertion_line: 27
 expression: "String::from_utf8(stdout.into_inner().unwrap()).unwrap()"
 ---
 export type ExtensibleMapExample = (({
-["optional-key"]?:(number),[key: string]:(any)}));
+"optional-key"?:(number),[key: string]:(any)}));
 export type ExtensibleMapExample2 = (({
-["optional-key"]?:(number),[key: string]:(any)}));
+"optional-key"?:(number),[key: string]:(any)}));
 export type ExtensibleMapExample3 = (({
 "optional-key"?:(number),[key: string]:(any)}));
 export type ExtensibleMapExample4 = (({
 ["optional-key"]?:(number),[key: string]:(any)}));
-
+export type ExampleMap = (({
+"hyphenated-key"?:(string),"another-key"?:(string),"standardIdentifier"?:(string),"1"?:(string)}));

--- a/tests/snapshots/zod__it_works_with_maps-2.snap
+++ b/tests/snapshots/zod__it_works_with_maps-2.snap
@@ -1,14 +1,14 @@
 ---
 source: tests/zod.rs
-expression: "String::from_utf8(stdout.into_inner().unwrap()).unwrap()"
+expression: "String :: from_utf8(stdout.into_inner().unwrap()).unwrap()"
 ---
 export const ExtensibleMapExampleSchema = z.lazy(() => z.object({
-[z.literal("optional-key")]:z.number().int().optional()}).and(
+"optional-key":z.number().int().optional()}).and(
 z.record(
 z.string(),z.any()))
 );
 export const ExtensibleMapExample2Schema = z.lazy(() => z.object({
-[z.literal("optional-key")]:z.number().int().optional()}).and(
+"optional-key":z.number().int().optional()}).and(
 z.record(
 z.string(),z.any()))
 );
@@ -22,4 +22,5 @@ z.literal("optional-key"),z.number().int().optional()).and(
 z.record(
 z.string(),z.any()))
 );
-
+export const ExampleMapSchema = z.lazy(() => z.object({
+"hyphenated-key":z.string().optional(),"another-key":z.string().optional(),"standardIdentifier":z.string().optional(),"1":z.string().optional()}));


### PR DESCRIPTION
Fixes #79

### Problem
When converting CDDL maps with literal property keys (e.g., `"hyphenated-key": text` or `1: text`) to Zod format (`-f zod`), `cddlconv` formatted them as `[z.literal(...)]: ...`.

Because `z.object({...})` is evaluated as a JavaScript object literal at runtime, `[z.
literal(...)]` is treated as a JavaScript computed property name. Evaluating the object
reference calls `.toString()`, converting all literal keys to `"[object Object]"` and causing
property collisions that corrupt the schema.

In addition, TypeScript output (`-f type-script`) emitted computed property brackets
`["hyphenated-key"]?: ...` rather than standard quoted property names `"hyphenated-key"?: ...`.

### Solution
- **Zod Generator**: Updated `MemberKey::Value` in `src/engines/zod.rs` to format literal
  keys directly as quoted string properties (`"<key>":`) instead of routing them through
  `visit_value` wrapped in `[z.literal(...)]:`.
- **TypeScript Generator**: Updated `MemberKey::Value` in `src/engines/typescript.rs` to
  emit standard quoted property syntax (`"<key>"`) instead of computed brackets `["<key>"]`.
- **Tests**: Added test coverage in `examples/rfc-examples/maps.cddl` for maps containing
  hyphenated string literals, standard identifiers, and integer literal keys, and updated
  snapshots accordingly.

### Example

**CDDL Input:**
```cddl
ExampleMap = {
    ? "hyphenated-key": text,
    ? "another-key": text,
    ? standardIdentifier: text,
    ? 1: text,
}
```

**Before (Zod):**
```typescript
export const ExampleMapSchema = z.lazy(() => z.object({
[z.literal("hyphenated-key")]:z.string().optional(),[z.literal("another-key")]:z.string().optional(),"standardIdentifier":z.string().optional(),[z.literal(1)]:z.string().optional()}));
```

**After (Zod):**
```typescript
export const ExampleMapSchema = z.lazy(() => z.object({
"hyphenated-key":z.string().optional(),"another-key":z.string().optional(), "standardIdentifier":z.string().optional(),"1":z.string().optional()}));
```