### PR TITLE
build: configure trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,14 +12,18 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write     # Required for OIDC token exchange
     steps:
       - name: Check out repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Set up Rust
         run: rustup update stable && rustup default stable
+      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth
       - name: Run tests
         run: cargo test
       - name: Publish
         env:
-          CARGO_TOKEN: ${{secrets.CARGO_TOKEN}}
-        run: cargo publish --token ${CARGO_TOKEN}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish


### PR DESCRIPTION
Followed these docs https://crates.io/docs/trusted-publishing