### PR TITLE
fix: generate const object and type alias for string enums

### DIFF
--- a/examples/enums.cddl
+++ b/examples/enums.cddl
@@ -1,0 +1,10 @@
+; Test for enum types
+qEnum = "qValue" / "qValue2"
+
+network.SameSite = "strict" / "lax" / "none"
+
+network.Cookie = {
+    name: text,
+    value: text,
+    sameSite: network.SameSite,
+}

--- a/src/engines/typescript.rs
+++ b/src/engines/typescript.rs
@@ -18,7 +18,7 @@ use std::io::Write;
 
 use cddl::{ast::Occurrence, visitor::Visitor, Error};
 
-use crate::util::{is_alphaspace, split_namespaced, to_namespaced, to_pascalcase};
+use crate::util::{is_enum_value, split_namespaced, to_namespaced, to_pascalcase};
 
 const MAX_ELEMENTS: usize = 1 << 3;
 
@@ -137,7 +137,7 @@ impl<'a, 'b: 'a, 'c, Stdout: Write, Stderr: Write> Engine<Stdout, Stderr> {
                 "export type Flatten<T extends unknown[]> = T extends (infer S)[][] \
                     ? S[] \
                     : never;"
-            )
+            );
         }
     }
     /// Requires all type choices to be strings.
@@ -146,7 +146,7 @@ impl<'a, 'b: 'a, 'c, Stdout: Write, Stderr: Write> Engine<Stdout, Stderr> {
             if let cddl::ast::Type2::TextValue { value, .. } = &choice.type1.type2 {
                 writeln!(
                     self.stdout,
-                    "{} = \"{}\",",
+                    "{}: \"{}\",",
                     to_pascalcase(value),
                     value.to_string()
                 );
@@ -549,16 +549,33 @@ impl<'a, 'b: 'a, Stdout: Write, Stderr: Write> Visitor<'a, 'b, Error> for Engine
         for namespace in &namespaces {
             writeln!(self.stdout, "export namespace {} {{", namespace);
         }
-        if tr.value.type_choices.iter().all(|choice| {
-            if let cddl::ast::Type2::TextValue { value, .. } = &choice.type1.type2 {
-                is_alphaspace(value)
-            } else {
-                false
-            }
-        }) {
-            write!(self.stdout, "export const enum {} {{", type_name);
+        if tr.value.type_choices.len() > 1
+            && tr.value.type_choices.iter().all(|choice| {
+                if let cddl::ast::Type2::TextValue { value, .. } = &choice.type1.type2 {
+                    is_enum_value(value)
+                } else {
+                    false
+                }
+            })
+        {
+            self.visit_type_for_comment(&tr.value)?;
+            write!(self.stdout, "export const {} = {{", type_name);
             self.visit_enum_type(&tr.value)?;
-            writeln!(self.stdout, "}}");
+            writeln!(self.stdout, "}} as const;");
+            write!(self.stdout, "export type ");
+            self.visit_identifier_with_params(
+                &cddl::ast::Identifier {
+                    ident: &type_name,
+                    socket: None,
+                    span: Default::default(),
+                },
+                &tr.generic_params,
+            )?;
+            writeln!(
+                self.stdout,
+                " = (typeof {})[keyof typeof {}];",
+                type_name, type_name
+            );
         } else {
             self.visit_type_for_comment(&tr.value)?;
             write!(self.stdout, "export type ");

--- a/src/engines/zod.rs
+++ b/src/engines/zod.rs
@@ -335,7 +335,9 @@ impl<'a, 'b: 'a, 'c, Stdout: Write, Stderr: Write> Engine<Stdout, Stderr> {
                 write!(self.stdout, "z.array(");
                 self.visit_type(&entry.entry_type)?;
                 write!(self.stdout, ")");
-                if lower > 0 {
+                if lower == 1 {
+                    write!(self.stdout, ".nonempty()");
+                } else if lower > 1 {
                     write!(self.stdout, ".min({})", lower);
                 }
                 if upper < usize::MAX {

--- a/src/util.rs
+++ b/src/util.rs
@@ -46,3 +46,33 @@ pub fn is_alphaspace<T: AsRef<str>>(value: T) -> bool {
         .bytes()
         .all(|ch| b'a' <= ch && ch <= b'z' || ch == b' ')
 }
+
+pub fn is_enum_value<T: AsRef<str>>(value: T) -> bool {
+    let val = value.as_ref();
+    let pascal = to_pascalcase(val);
+    if pascal.is_empty() {
+        return false;
+    }
+    let mut chars = pascal.chars();
+    let first = chars.next().unwrap();
+    (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_enum_value() {
+        assert!(is_enum_value("invalid argument"));
+        assert!(is_enum_value("qValue"));
+        assert!(is_enum_value("qValue2"));
+        assert!(is_enum_value("user-agent"));
+        assert!(is_enum_value("strict"));
+        assert!(is_enum_value("none"));
+        assert!(!is_enum_value("2g"));
+        assert!(!is_enum_value(""));
+        assert!(!is_enum_value("foo.bar"));
+    }
+}

--- a/tests/snapshots/typescript__it_works-2.snap
+++ b/tests/snapshots/typescript__it_works-2.snap
@@ -28,25 +28,26 @@ export type JsInt = (number);
  * Must be between `0` and `9007199254740991`, inclusive.
  */
 export type JsUint = (number);
-export const enum ErrorCode {InvalidArgument = "invalid argument",
-InvalidSessionId = "invalid session id",
-MoveTargetOutOfBounds = "move target out of bounds",
-NoSuchAlert = "no such alert",
-NoSuchElement = "no such element",
-NoSuchFrame = "no such frame",
-NoSuchHandle = "no such handle",
-NoSuchHistoryEntry = "no such history entry",
-NoSuchIntercept = "no such intercept",
-NoSuchNode = "no such node",
-NoSuchRequest = "no such request",
-NoSuchScript = "no such script",
-SessionNotCreated = "session not created",
-UnableToCaptureScreen = "unable to capture screen",
-UnableToCloseBrowser = "unable to close browser",
-UnknownCommand = "unknown command",
-UnknownError = "unknown error",
-UnsupportedOperation = "unsupported operation",
-}
+export const ErrorCode = {InvalidArgument: "invalid argument",
+InvalidSessionId: "invalid session id",
+MoveTargetOutOfBounds: "move target out of bounds",
+NoSuchAlert: "no such alert",
+NoSuchElement: "no such element",
+NoSuchFrame: "no such frame",
+NoSuchHandle: "no such handle",
+NoSuchHistoryEntry: "no such history entry",
+NoSuchIntercept: "no such intercept",
+NoSuchNode: "no such node",
+NoSuchRequest: "no such request",
+NoSuchScript: "no such script",
+SessionNotCreated: "session not created",
+UnableToCaptureScreen: "unable to capture screen",
+UnableToCloseBrowser: "unable to close browser",
+UnknownCommand: "unknown command",
+UnknownError: "unknown error",
+UnsupportedOperation: "unsupported operation",
+} as const;
+export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
 export type SessionCommand = (Session.End| Session.New| Session.Status| Session.Subscribe| Session.Unsubscribe);
 export type SessionResult = ((Session.NewResult| Session.StatusResult));
 export namespace Session {
@@ -173,10 +174,11 @@ export type NavigationInfo = (({
 "context":(BrowsingContext.BrowsingContext),"navigation":(BrowsingContext.Navigation| null),"timestamp":(JsUint),"url":(string)}));
 }
 export namespace BrowsingContext {
-export const enum ReadinessState {None = "none",
-Interactive = "interactive",
-Complete = "complete",
-}
+export const ReadinessState = {None: "none",
+Interactive: "interactive",
+Complete: "complete",
+} as const;
+export type ReadinessState = (typeof ReadinessState)[keyof typeof ReadinessState];
 }
 export namespace BrowsingContext {
 export type Activate = ({
@@ -238,9 +240,10 @@ export type Create = ({
 "method":("browsingContext.create"),"params":(BrowsingContext.CreateParameters)});
 }
 export namespace BrowsingContext {
-export const enum CreateType {Tab = "tab",
-Window = "window",
-}
+export const CreateType = {Tab: "tab",
+Window: "window",
+} as const;
+export type CreateType = (typeof CreateType)[keyof typeof CreateType];
 }
 export namespace BrowsingContext {
 export type CreateParameters = (({
@@ -561,10 +564,11 @@ export type AddInterceptParameters = (({
 ...((Network.UrlPattern)[])])}));
 }
 export namespace Network {
-export const enum InterceptPhase {BeforeRequestSent = "beforeRequestSent",
-ResponseStarted = "responseStarted",
-AuthRequired = "authRequired",
-}
+export const InterceptPhase = {BeforeRequestSent: "beforeRequestSent",
+ResponseStarted: "responseStarted",
+AuthRequired: "authRequired",
+} as const;
+export type InterceptPhase = (typeof InterceptPhase)[keyof typeof InterceptPhase];
 }
 export namespace Network {
 export type AddInterceptResult = (({
@@ -823,7 +827,16 @@ export type WorkletRealmInfo = ((Script.BaseRealmInfo&{
 "type":("worklet")}));
 }
 export namespace Script {
-export type RealmType = ("window"| "dedicated-worker"| "shared-worker"| "service-worker"| "worker"| "paint-worklet"| "audio-worklet"| "worklet");
+export const RealmType = {Window: "window",
+DedicatedWorker: "dedicated-worker",
+SharedWorker: "shared-worker",
+ServiceWorker: "service-worker",
+Worker: "worker",
+PaintWorklet: "paint-worklet",
+AudioWorklet: "audio-worklet",
+Worklet: "worklet",
+} as const;
+export type RealmType = (typeof RealmType)[keyof typeof RealmType];
 }
 export namespace Script {
 export type RemoteReference = ((Script.SharedReference| Script.RemoteObjectReference));
@@ -945,9 +958,10 @@ export type WindowProxyProperties = (({
 "context":(BrowsingContext.BrowsingContext)}));
 }
 export namespace Script {
-export const enum ResultOwnership {Root = "root",
-None = "none",
-}
+export const ResultOwnership = {Root: "root",
+None: "none",
+} as const;
+export type ResultOwnership = (typeof ResultOwnership)[keyof typeof ResultOwnership];
 }
 export namespace Script {
 export type SerializationOptions = (({
@@ -1083,11 +1097,12 @@ export type RealmDestroyedParameters = (({
 }
 export type LogEvent = (Log.EntryAdded);
 export namespace Log {
-export const enum Level {Debug = "debug",
-Info = "info",
-Warn = "warn",
-Error = "error",
-}
+export const Level = {Debug: "debug",
+Info: "info",
+Warn: "warn",
+Error: "error",
+} as const;
+export type Level = (typeof Level)[keyof typeof Level];
 }
 export namespace Log {
 export type Entry = ((Log.GenericLogEntry| Log.ConsoleLogEntry| Log.JavascriptLogEntry));
@@ -1152,10 +1167,11 @@ export type PointerSourceActions = (({
 ...((Input.PointerSourceAction)[])])}));
 }
 export namespace Input {
-export const enum PointerType {Mouse = "mouse",
-Pen = "pen",
-Touch = "touch",
-}
+export const PointerType = {Mouse: "mouse",
+Pen: "pen",
+Touch: "touch",
+} as const;
+export type PointerType = (typeof PointerType)[keyof typeof PointerType];
 }
 export namespace Input {
 export type PointerParameters = (({

--- a/tests/snapshots/typescript__it_works_with_enums-2.snap
+++ b/tests/snapshots/typescript__it_works_with_enums-2.snap
@@ -1,0 +1,19 @@
+---
+source: tests/typescript.rs
+expression: "String :: from_utf8(stdout.into_inner().unwrap()).unwrap()"
+---
+export const QEnum = {QValue: "qValue",
+QValue2: "qValue2",
+} as const;
+export type QEnum = (typeof QEnum)[keyof typeof QEnum];
+export namespace Network {
+export const SameSite = {Strict: "strict",
+Lax: "lax",
+None: "none",
+} as const;
+export type SameSite = (typeof SameSite)[keyof typeof SameSite];
+}
+export namespace Network {
+export type Cookie = (({
+"name":(string),"value":(string),"sameSite":(Network.SameSite)}));
+}

--- a/tests/snapshots/typescript__it_works_with_enums.snap
+++ b/tests/snapshots/typescript__it_works_with_enums.snap
@@ -1,0 +1,5 @@
+---
+source: tests/typescript.rs
+expression: "String :: from_utf8(stderr.into_inner().unwrap()).unwrap()"
+---
+

--- a/tests/snapshots/zod__it_works-2.snap
+++ b/tests/snapshots/zod__it_works-2.snap
@@ -280,7 +280,7 @@ LocateNodesSchema = z.lazy(() => z.object({
 }
 export namespace BrowsingContext {
 export const LocateNodesParametersSchema = z.lazy(() => z.object({
-"context":BrowsingContext.BrowsingContextSchema,"locator":BrowsingContext.LocatorSchema,"maxNodeCount":JsUintSchema.gte(1).optional(),"ownership":Script.ResultOwnershipSchema.optional(),"sandbox":z.string().optional(),"serializationOptions":Script.SerializationOptionsSchema.optional(),"startNodes":z.array(Script.SharedReferenceSchema).min(1).optional()}));
+"context":BrowsingContext.BrowsingContextSchema,"locator":BrowsingContext.LocatorSchema,"maxNodeCount":JsUintSchema.gte(1).optional(),"ownership":Script.ResultOwnershipSchema.optional(),"sandbox":z.string().optional(),"serializationOptions":Script.SerializationOptionsSchema.optional(),"startNodes":z.array(Script.SharedReferenceSchema).nonempty().optional()}));
 }
 export namespace BrowsingContext {
 export const LocateNodesResultSchema = z.lazy(() => z.object({
@@ -435,7 +435,7 @@ export const AuthCredentialsSchema = z.lazy(() => z.object({
 export namespace Network {
 export const 
 BaseParametersSchema = z.lazy(() => z.object({
-"context":z.union([BrowsingContext.BrowsingContextSchema,z.null()]),"isBlocked":z.boolean(),"navigation":z.union([BrowsingContext.NavigationSchema,z.null()]),"redirectCount":JsUintSchema,"request":Network.RequestDataSchema,"timestamp":JsUintSchema,"intercepts":z.array(Network.InterceptSchema).min(1).optional()}));
+"context":z.union([BrowsingContext.BrowsingContextSchema,z.null()]),"isBlocked":z.boolean(),"navigation":z.union([BrowsingContext.NavigationSchema,z.null()]),"redirectCount":JsUintSchema,"request":Network.RequestDataSchema,"timestamp":JsUintSchema,"intercepts":z.array(Network.InterceptSchema).nonempty().optional()}));
 }
 export namespace Network {
 export const BytesValueSchema = z.lazy(() => z.union([Network.StringValueSchema,Network.Base64ValueSchema]));
@@ -508,7 +508,7 @@ AddInterceptSchema = z.lazy(() => z.object({
 }
 export namespace Network {
 export const AddInterceptParametersSchema = z.lazy(() => z.object({
-"phases":z.array(Network.InterceptPhaseSchema).min(1),"urlPatterns":z.array(Network.UrlPatternSchema).optional()}));
+"phases":z.array(Network.InterceptPhaseSchema).nonempty(),"urlPatterns":z.array(Network.UrlPatternSchema).optional()}));
 }
 export namespace Network {
 export const InterceptPhaseSchema = z.lazy(() => z.enum(["beforeRequestSent","responseStarted","authRequired",]));
@@ -966,7 +966,7 @@ AddPreloadScriptSchema = z.lazy(() => z.object({
 }
 export namespace Script {
 export const AddPreloadScriptParametersSchema = z.lazy(() => z.object({
-"functionDeclaration":z.string(),"arguments":z.array(Script.ChannelValueSchema).optional(),"contexts":z.array(BrowsingContext.BrowsingContextSchema).min(1).optional(),"sandbox":z.string().optional()}));
+"functionDeclaration":z.string(),"arguments":z.array(Script.ChannelValueSchema).optional(),"contexts":z.array(BrowsingContext.BrowsingContextSchema).nonempty().optional(),"sandbox":z.string().optional()}));
 }
 export namespace Script {
 export const AddPreloadScriptResultSchema = z.lazy(() => z.object({

--- a/tests/snapshots/zod__it_works_with_enums-2.snap
+++ b/tests/snapshots/zod__it_works_with_enums-2.snap
@@ -1,0 +1,12 @@
+---
+source: tests/zod.rs
+expression: "String :: from_utf8(stdout.into_inner().unwrap()).unwrap()"
+---
+export const QEnumSchema = z.lazy(() => z.enum(["qValue","qValue2",]));
+export namespace Network {
+export const SameSiteSchema = z.lazy(() => z.enum(["strict","lax","none",]));
+}
+export namespace Network {
+export const CookieSchema = z.lazy(() => z.object({
+"name":z.string(),"value":z.string(),"sameSite":Network.SameSiteSchema}));
+}

--- a/tests/snapshots/zod__it_works_with_enums.snap
+++ b/tests/snapshots/zod__it_works_with_enums.snap
@@ -1,0 +1,5 @@
+---
+source: tests/zod.rs
+expression: "String :: from_utf8(stderr.into_inner().unwrap()).unwrap()"
+---
+

--- a/tests/typescript.rs
+++ b/tests/typescript.rs
@@ -45,3 +45,4 @@ test!(
     it_works_with_array_occurences,
     "examples/array_occurences.cddl"
 );
+test!(it_works_with_enums, "examples/enums.cddl");

--- a/tests/zod.rs
+++ b/tests/zod.rs
@@ -44,3 +44,4 @@ test!(
     it_works_with_array_occurences,
     "examples/array_occurences.cddl"
 );
+test!(it_works_with_enums, "examples/enums.cddl");


### PR DESCRIPTION
### Summary
Fixes #19 by:
1. Replacing TypeScript `const enum` generation with a `const` object paired with a type
  alias union (`(typeof Enum)[keyof typeof Enum]`).
2. Generating `z.array(...).nonempty()` for non-empty arrays with a minimum occurrence of
  1 in the Zod engine.

---

### Motivation & Problem

Previously, types inferred from generated Zod schemas (`z.infer<typeof Schema>`) were
  incompatible with the generated TypeScript types in two scenarios, requiring manual `as`
  casts in consuming code:

1. **String Enums (Nominal typing mismatch):**
   The TypeScript engine emitted string enums as `export const enum Enum { ... }`. Because
  TypeScript enums are nominal, string literal unions from Zod (`z.enum(['val1', 'val2'])` ->
  `"val1" | "val2"`) could not be assigned to the enum type:
    ```text
   error TS2820: Type '"qValue1"' is not assignable to type 'qEnum'. Did you mean 'qEnum.qValue2'?
    ```

  2. Non-Empty Arrays `([T, ...T[]] vs T[])`:
  For non-empty arrays `(occurrence + / 1*)`, the TypeScript engine generated non-empty tuple
  `types [T, ...T[]]`. However, the Zod engine generated `z.array(...).min(1)`, which infers `T[]`
  (regular array). In TypeScript, T[] cannot be assigned to `[T, ...T[]]`:
    ```text
    error TS2322: Type 'string[]' is not assignable to type '[string, ...string[]]'.
    Source provides no match for required element at position 0 in target.
    ```

  ──────
  ### Solution

  1. Enum Generation (typescript.rs):
  • Generate enums as as const object dictionaries with a merged type alias union:
```
	export const QEnum = {
	  QValue1: "qValue1",
	  QValue2: "qValue2",
	} as const;
	export type QEnum = (typeof QEnum)[keyof typeof QEnum];
```

  • Preserves runtime member access (e.g. QEnum.QValue1) while ensuring structural
  compatibility with Zod's `z.enum([...])`.
  2. Non-Empty Array Validation (zod.rs):
  • When lower == 1, emit .nonempty() instead of .min(1):
	`z.array(TypeSchema).nonempty()`

  • This causes Zod to infer [T, ...T[]], perfectly matching the TypeScript engine's
  emitted tuple types.
  3. Expanded Identifier Validation (util.rs):
  • Added `is_enum_value` to allow alphanumeric, hyphenated, and underscore-separated values
  (e.g., qValue2, dedicated-worker) whose PascalCase transformation produces a valid
  JavaScript identifier.
  4. Feature Fix (typescript.rs):
  • Fixed a missing semicolon when compiling with --features vector_groups.
  5. Tests:
  • Added enums.cddl test fixture and snapshot test cases across tests/typescript.rs and
  tests/zod.rs.
  • Updated existing snapshots for both TypeScript and Zod engines.